### PR TITLE
Fix cross_val_predict usage and RMSE output

### DIFF
--- a/Classification/main_all_in_one.py
+++ b/Classification/main_all_in_one.py
@@ -135,12 +135,13 @@ print("len(ovr_clf.estimator): ",len(ovr_clf.estimators_))
 forest_clf.fit(x_train, y_train)
 print(forest_clf.predict([some_digit]))
 print("forest_clf.predict_proba: ",forest_clf.predict_proba([some_digit]))
-print("cross_val_predict(x_train: ",cross_val_predict(x_train, y_train_5, cv=3, method="predict_proba"))
+print("cross_val_predict(x_train: ",
+      cross_val_predict(forest_clf, x_train, y_train_5, cv=3, method="predict_proba"))
 
 #Imporve by scaling the input
 scaler = StandardScaler()
 x_train_scaled = scaler.fit_transform(x_train.astype(np.float64))
-y_train_pred = cross_val_predict(x_train_scaled, y_train, cv=3, method="predict_proba")
+y_train_pred = cross_val_predict(sgd_clf, x_train_scaled, y_train_5, cv=3)
 print("cross_val_predict(x_train_scaled: ",  y_train_pred )
 
 #Error analysis

--- a/HousePricing/models/train.py
+++ b/HousePricing/models/train.py
@@ -54,7 +54,7 @@ def train_all_models(housing_prepared,housing_labels):
     scores = cross_val_score(forest_reg, housing_prepared, housing_labels,
     scoring="neg_mean_squared_error", cv=10)
     forst_rmse_scores = np.sqrt(-scores)
-    print("***************************forest Reg RMSE SCORES",tree_rmse_scores)
+    print("***************************forest Reg RMSE SCORES", forst_rmse_scores)
     print("Mean SCORES",forst_rmse_scores.mean())
     print("std SCORES",forst_rmse_scores.std())
 


### PR DESCRIPTION
## Summary
- correct `cross_val_predict` calls in the classification example
- fix RMSE output for the RandomForest in training helper

## Testing
- `python -m py_compile Classification/main_all_in_one.py HousePricing/models/train.py`

------
https://chatgpt.com/codex/tasks/task_e_685cae2c40688331bcb38cab17fe0b86